### PR TITLE
pads filename with '0' when index less than 100

### DIFF
--- a/comic-fuz-downloader.user.js
+++ b/comic-fuz-downloader.user.js
@@ -324,7 +324,7 @@
     }
 
     async function getImageToZip(image, zip, progress, index) {
-      const fileName = `${index}.jpeg`
+      const fileName = `${index.toString().padStart(3, '0')}.jpeg`
       try {
         const imageData = await decryptImage(image)
         addImageToZip(fileName, imageData, zip)


### PR DESCRIPTION
对`getImageToZip`函数做了一点小改动，使得文件名长度均为3位，索引少于3位时补0，即`001.jpeg` `014.jpeg` `514.jpeg`。
考虑到ComicFuz漫画的特点，3位应该够了吧（笑