### PR TITLE
Add buttons back to the new UI

### DIFF
--- a/comic-fuz-downloader.user.js
+++ b/comic-fuz-downloader.user.js
@@ -193,10 +193,11 @@
       <div id="downloader"></div>
     `)
     divDownload.css({
-      'margin-left': '24px',
-      flex: '1 1',
-      color: '#2c3438',
-      width: 'fit-content',
+      "grid-area": 'rright',
+      display: 'flex',
+      "align-items": 'center',
+      gap: '24px',
+      color: '#929ea5',
     })
 
     const spanDownloadButton = $(`
@@ -290,20 +291,22 @@
 
     function checkAndLoad() {
       if ($('#downloader').length === 0) {
-        $('div[class^="ViewerFooter_footer__buttons__"]:first').append(divDownload)
+        $('div[class^="InternalViewerFooter_footer__wrapper__"]:first').append(divDownload)
       }
     }
 
     const maxRetry = 10
     ;(async () => {
       for (let i = 0; i < maxRetry; ++i) {
-        if ($('div[class^="ViewerFooter_footer__"]').length) {
-          const zoomContainer = $('div[class^="ViewerFooter_footer__zoomContainer__"]:first').attr('class')
+        const footer = $('div[class^="InternalViewerFooter_footer__wrapper__"]:first')
+        if (footer.length) {
+
           $('head').append(`<style type="text/css">
-              .${zoomContainer} {
-                flex: 0 1 270px;
+              .${footer.attr('class')} {
+                grid-template-areas: "left center right rright";
+                grid-template-columns: auto 1fr auto auto;
               }
-            </style>`)
+          </style>`)
 
           checkAndLoad()
           $(document).on('click', checkAndLoad)

--- a/comic-fuz-downloader.user.js
+++ b/comic-fuz-downloader.user.js
@@ -298,32 +298,31 @@
     const maxRetry = 10
     ;(async () => {
       for (let i = 0; i < maxRetry; ++i) {
-        const footer = $('div[class^="InternalViewerFooter_footer__wrapper__"]:first')
-        if (footer.length) {
+        if ($('div[class^="InternalViewerFooter_footer__wrapper__"]').length) {
+            const footer = $('div[class^="InternalViewerFooter_footer__wrapper__"]:first').attr('class')
+            $('head').append(`<style type="text/css">
+                .${footer} {
+                  grid-template-areas: "left center right rright";
+                  grid-template-columns: auto 1fr auto auto;
+                }
+            </style>`)
 
-          $('head').append(`<style type="text/css">
-              .${footer.attr('class')} {
-                grid-template-areas: "left center right rright";
-                grid-template-columns: auto 1fr auto auto;
-              }
-          </style>`)
-
-          checkAndLoad()
-          $(document).on('click', checkAndLoad)
-          setDownloaderBusy()
-          setText('Initializing...')
-          try {
-            await initialize()
-            initRange()
-            setDownloaderReady()
-          } catch (err) {
-            setDownloaderReady('Initialization failed!')
+            checkAndLoad()
+            $(document).on('click', checkAndLoad)
+            setDownloaderBusy()
+            setText('Initializing...')
+            try {
+              await initialize()
+              initRange()
+              setDownloaderReady()
+            } catch (err) {
+              setDownloaderReady('Initialization failed!')
+            }
+            break
+          } else {
+            await delay(500)
           }
-          break
-        } else {
-          await delay(500)
         }
-      }
     })()
 
     async function downloadAsZip(metadata, pageFrom, pageTo) {

--- a/comic-fuz-downloader.user.js
+++ b/comic-fuz-downloader.user.js
@@ -321,8 +321,7 @@
             const zoomContainer = $('div[class^="ViewerFooter_footer__zoomContainer__"]:first').attr('class')
             $('head').append(`<style type="text/css">
                 .${zoomContainer} {
-                  grid-template-areas: "left center right rright";
-                  grid-template-columns: auto 1fr auto auto;
+                  flex: 0 1 270px;
                 }
               </style>`)
           } else {

--- a/comic-fuz-downloader.user.js
+++ b/comic-fuz-downloader.user.js
@@ -192,13 +192,24 @@
     const divDownload = $(`
       <div id="downloader"></div>
     `)
-    divDownload.css({
-      "grid-area": 'rright',
-      display: 'flex',
-      "align-items": 'center',
-      gap: '24px',
-      color: '#929ea5',
-    })
+    const path = new URL(window.location.href).pathname.split('/')
+    const is_manga = (path[path.length - 3].toLowerCase()) === 'manga'
+    if (is_manga) {
+      divDownload.css({
+        "grid-area": 'rright',
+        display: 'flex',
+        "align-items": 'center',
+        gap: '24px',
+        color: '#929ea5',
+      })
+    } else {
+      divDownload.css({
+        'margin-left': '24px',
+        flex: '1 1',
+        color: '#2c3438',
+        width: 'fit-content',
+      })
+    }
 
     const spanDownloadButton = $(`
       <span id="downloadButton">
@@ -291,21 +302,38 @@
 
     function checkAndLoad() {
       if ($('#downloader').length === 0) {
-        $('div[class^="InternalViewerFooter_footer__wrapper__"]:first').append(divDownload)
+        if (is_manga) {
+          $('div[class^="InternalViewerFooter_footer__wrapper__"]:first').append(divDownload)
+        } else {
+          $('div[class^="ViewerFooter_footer__buttons__"]:first').append(divDownload)
+        }
       }
     }
 
     const maxRetry = 10
     ;(async () => {
       for (let i = 0; i < maxRetry; ++i) {
-        if ($('div[class^="InternalViewerFooter_footer__wrapper__"]').length) {
-          const footer = $('div[class^="InternalViewerFooter_footer__wrapper__"]:first').attr('class')
-          $('head').append(`<style type="text/css">
-              .${footer} {
-                grid-template-areas: "left center right rright";
-                grid-template-columns: auto 1fr auto auto;
-              }
-            </style>`)
+        const old_ui = !is_manga && $('div[class^="ViewerFooter_footer__"]').length
+        const new_ui = is_manga && $('div[class^="InternalViewerFooter_footer__wrapper__"]').length
+        if (old_ui || new_ui) {
+
+          if (old_ui) {
+            const zoomContainer = $('div[class^="ViewerFooter_footer__zoomContainer__"]:first').attr('class')
+            $('head').append(`<style type="text/css">
+                .${zoomContainer} {
+                  grid-template-areas: "left center right rright";
+                  grid-template-columns: auto 1fr auto auto;
+                }
+              </style>`)
+          } else {
+            const footer = $('div[class^="InternalViewerFooter_footer__wrapper__"]:first').attr('class')
+            $('head').append(`<style type="text/css">
+                .${footer} {
+                  grid-template-areas: "left center right rright";
+                  grid-template-columns: auto 1fr auto auto;
+                }
+              </style>`)
+          }
 
           checkAndLoad()
           $(document).on('click', checkAndLoad)

--- a/comic-fuz-downloader.user.js
+++ b/comic-fuz-downloader.user.js
@@ -299,30 +299,30 @@
     ;(async () => {
       for (let i = 0; i < maxRetry; ++i) {
         if ($('div[class^="InternalViewerFooter_footer__wrapper__"]').length) {
-            const footer = $('div[class^="InternalViewerFooter_footer__wrapper__"]:first').attr('class')
-            $('head').append(`<style type="text/css">
-                .${footer} {
-                  grid-template-areas: "left center right rright";
-                  grid-template-columns: auto 1fr auto auto;
-                }
+          const footer = $('div[class^="InternalViewerFooter_footer__wrapper__"]:first').attr('class')
+          $('head').append(`<style type="text/css">
+              .${footer} {
+                grid-template-areas: "left center right rright";
+                grid-template-columns: auto 1fr auto auto;
+              }
             </style>`)
 
-            checkAndLoad()
-            $(document).on('click', checkAndLoad)
-            setDownloaderBusy()
-            setText('Initializing...')
-            try {
-              await initialize()
-              initRange()
-              setDownloaderReady()
-            } catch (err) {
-              setDownloaderReady('Initialization failed!')
-            }
-            break
-          } else {
-            await delay(500)
+          checkAndLoad()
+          $(document).on('click', checkAndLoad)
+          setDownloaderBusy()
+          setText('Initializing...')
+          try {
+            await initialize()
+            initRange()
+            setDownloaderReady()
+          } catch (err) {
+            setDownloaderReady('Initialization failed!')
           }
+          break
+        } else {
+          await delay(500)
         }
+      }
     })()
 
     async function downloadAsZip(metadata, pageFrom, pageTo) {


### PR DESCRIPTION
This is a fix for #10. The buttons are added right of the zoom and orientation elements like this:
![comicfuzexample](https://github.com/CircleLiu/Comic-Fuz-Downloader/assets/8273440/ed3eff0a-8550-40ac-853c-d9ce0029d240)
